### PR TITLE
Update User Discord IDs to be up to 32 characters in length

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@rpitv/glimpse-api",
   "description": "GraphQL API for interacting with the Glimpse core",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "private": true,
   "license": "MIT",
   "repository": {

--- a/apps/api/src/types/user/user.entity.ts
+++ b/apps/api/src/types/user/user.entity.ts
@@ -57,7 +57,7 @@ export class User implements PrismaUser {
      * Discord account ID for this user, or null if the user does not have a linked Discord account.
      */
     @IsNumberString()
-    @Length(18, 18)
+    @Length(18, 32)
     @IsOptional()
     @Field(() => String, { nullable: true })
     discord: string | null;

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "glimpse-ui",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "private": true,
   "license": "MIT",
   "repository": {

--- a/apps/ui/src/components/user/UserDetailsInput.vue
+++ b/apps/ui/src/components/user/UserDetailsInput.vue
@@ -8,7 +8,7 @@
         <n-input maxlength="300" v-model:value="inputUser.mail" />
       </n-form-item-grid-item>
       <n-form-item-grid-item path="discord" label="Discord ID">
-        <n-input minlength="18" maxlength="18" v-model:value="inputUser.discord" />
+        <n-input minlength="18" maxlength="32" v-model:value="inputUser.discord" />
       </n-form-item-grid-item>
     </n-grid>
   </n-form>
@@ -93,8 +93,8 @@ const rules: FormRules = {
         if(!value) {
           return;
         }
-        if(!validator.isNumeric(value) || value.length !== 18) {
-          return new Error("Discord IDs must be 18 digits long.");
+        if(!validator.isNumeric(value) || value.length < 18 || value.length > 32) {
+          return new Error("Discord IDs must be 18-32 digits long.");
         }
       }
     }

--- a/apps/ui/src/components/user/UserDetailsInput/UserDetails.vue
+++ b/apps/ui/src/components/user/UserDetailsInput/UserDetails.vue
@@ -39,8 +39,8 @@ const emailRule = () => {
 const discordRule = () => {
   if (!props.userData.discord)
     return true;
-  if (!validator.isNumeric(props.userData.discord as string) || props.userData.discord?.length !== 18)
-    return "Discord IDs must be 18 digits long";
+  if (!validator.isNumeric(props.userData.discord as string) || props.userData.discord?.length < 18 || props.userData.discord?.length > 32)
+    return "Discord IDs must be 18-32 digits long";
   return true;
 }
 

--- a/packages/prisma/migrations/20250108004402_extend_discord_id/migration.sql
+++ b/packages/prisma/migrations/20250108004402_extend_discord_id/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "users" ALTER COLUMN "discord" SET DATA TYPE CHAR(32);

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -352,7 +352,7 @@ model User {
   username         String           @unique(map: "users_username_uindex") @db.VarChar(8)
   mail             String           @unique(map: "users_mail_uindex") @db.VarChar(300)
   personId         BigInt?          @map("person")
-  discord          String?          @unique(map: "users_discord_uindex") @db.Char(18)
+  discord          String?          @unique(map: "users_discord_uindex") @db.Char(32)
   password         String?          @db.VarChar(300)
   joined           DateTime         @default(now()) @db.Timestamp(6)
   accessLogs       AccessLog[]


### PR DESCRIPTION
Some user accounts are now using 19 characters for their ID length. Update to max of 32 for sufficient future-proofing.